### PR TITLE
Serve docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -144,3 +144,4 @@ node_modules/
 dist/
 northstar.db
 instance
+northstar/static/docs/openapi

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ node_modules/
 dist/
 northstar.db
 instance
+northstar/static/docs/openapi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-default: ## Run app
+OPENAPI_DIST := northstar/static/docs/openapi
+default: doc ## Run app
 	@. ./venv/bin/activate && python -m northstar
 
 coverage:
@@ -7,10 +8,10 @@ coverage:
 	@ . ./venv/bin/activate  && coverage xml
 
 doc: ## Generate documentation
-	@-rm -rf dist
-	@-mkdir -p dist/openapi/
+	@-rm -rf $(OPENAPI_DIST)
+	@-mkdir -p $(OPENAPI_DIST)
 	@cd ./docs/openapi/  && yarn install && yarn html
-	@cp -r ./docs/openapi/dist/* dist/openapi/
+	@cp -r ./docs/openapi/dist/* $(OPENAPI_DIST)
 
 docker: ## Build Docker image from source
 	docker build -t forgedfed/northstar .

--- a/northstar/pages.py
+++ b/northstar/pages.py
@@ -17,12 +17,12 @@ Search page
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import subprocess
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, send_from_directory
 
 VERSION = "0.1.0"
-instance_maintainer = "foo@example.com"
+INSTANCE_MAINTAINER = "foo@example.com"
 GIT_HASH = subprocess.run(
-    ["git", "rev-parse", "HEAD"], capture_output=True
+    ["git", "rev-parse", "HEAD"], capture_output=True, check=True
 ).stdout.decode("utf-8")
 GITHUB_LINK = f"https://github.com/forgefedv2/northstar/tree/{GIT_HASH}"
 
@@ -35,7 +35,13 @@ def get_search_page():
     return render_template(
         "index.html",
         version=VERSION,
-        admin_email=instance_maintainer,
+        admin_email=INSTANCE_MAINTAINER,
         git_hash=GIT_HASH[0:10],
         github_link=GITHUB_LINK,
     )
+
+
+@bp.route("/docs/openapi/", methods=["GET"])
+def get_openapi_docs():
+    """OpenAPI Docs page"""
+    return send_from_directory("static/docs/openapi", "index.html")

--- a/northstar/templates/footer.html
+++ b/northstar/templates/footer.html
@@ -55,6 +55,18 @@
       >
         v{{ version }}-{{ git_hash }}
       </a>
+
+      <div class="footer__column-divider">|</div>
+      <a
+        class="footer__link"
+        href="/docs/openapi/"
+        target="_blank"
+        rel="noopener"
+        title="OpenAPI docs"
+      >
+        OpenAPI docs
+      </a>
+
     </div>
   </div>
 </footer>


### PR DESCRIPTION
This PR introduces the following changes:

- serve OpenAPI docs at `/docs/openapi/`
- rig docker to build and serve the same